### PR TITLE
Added spin widget to indicate network path switching process.

### DIFF
--- a/src/gui/accountsettings.cpp
+++ b/src/gui/accountsettings.cpp
@@ -235,6 +235,12 @@ AccountSettings::AccountSettings(const AccountStatePtr &accountState, QWidget *p
     });
     ui->stackedWidget->setCurrentWidget(ui->folderListPage);
 
+    connect(_accountState.get(), &AccountState::networkUpdateState, this, [this](bool inProgress) {
+        ui->networkIndicator->setVisible(inProgress);
+        ui->networkIndicator->startAnimation();
+    });
+    ui->networkIndicator->setVisible(false);
+
     connect(Theme::instance(), &Theme::themeChanged, this, &AccountSettings::onThemeChanged);
     onThemeChanged(Theme::instance()->isDarkTheme());
 }

--- a/src/gui/accountsettings.ui
+++ b/src/gui/accountsettings.ui
@@ -30,6 +30,22 @@
     <widget class="QWidget" name="accountStatus" native="true">
      <layout class="QHBoxLayout" name="horizontalLayout_4">
       <item>
+       <widget class="QProgressIndicator" name="networkIndicator" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16</width>
+          <height>16</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="connectLabel">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">

--- a/src/gui/accountstate.cpp
+++ b/src/gui/accountstate.cpp
@@ -735,6 +735,7 @@ void AccountState::setUpdateDeviceProgress(bool inProgress)
 {
     _updateDeviceInProgress = inProgress;
     qCDebug(lcAccountState) << "inProgress" << inProgress;
+    emit networkUpdateState(inProgress);
 }
 
 void AccountState::slotConnectionValidatorResult(ConnectionValidator::Status status, const QStringList &errors)

--- a/src/gui/accountstate.h
+++ b/src/gui/accountstate.h
@@ -187,6 +187,7 @@ signals:
     void urlUpdated();
     void urlChanged(const QUuid& id);
     void isSettingUpChanged();
+    void networkUpdateState(bool inProgress);
 
     // internal signal to be able to finish processing device path update when "Skip" code dialog pressed
     void pathUpdateFinished(bool skippedCode, const QList<DevicePath>& paths);


### PR DESCRIPTION
[HCNOVEO-1275] [Files Desktop] Show non blocking toast while sync device in background